### PR TITLE
Improve span context handling for dropped traces and fix context leaks

### DIFF
--- a/lib/instana/instrumentation/rack.rb
+++ b/lib/instana/instrumentation/rack.rb
@@ -33,7 +33,7 @@ module Instana
       current_span.record_exception(e) if ::Instana.tracer.tracing?
       raise
     ensure
-      finalize_trace(current_span, kvs, headers, trace_context) if ::Instana.tracer.tracing?
+      finalize_trace(current_span, kvs, headers, trace_context)
     end
 
     private
@@ -121,10 +121,16 @@ module Instana
     end
 
     def finalize_trace(current_span, kvs, headers, trace_context)
-      set_response_headers(headers, trace_context) if headers
-      current_span.add_attributes(kvs)
-      OpenTelemetry::Context.detach(@trace_token) if @trace_token
-      current_span.finish
+      if ::Instana.tracer.tracing?
+        set_response_headers(headers, trace_context) if headers
+        current_span.add_attributes(kvs)
+        current_span.finish
+      end
+    ensure
+      if @trace_token
+        OpenTelemetry::Context.detach(@trace_token)
+        @trace_token = nil
+      end
     end
 
     def set_response_headers(headers, trace_context)

--- a/lib/instana/trace.rb
+++ b/lib/instana/trace.rb
@@ -72,16 +72,7 @@ module Instana
     # @param [SpanContext] span_context SpanContext to be wrapped
     # @return [Span]
     def non_recording_span(span_context)
-      span = Instana::Span.allocate
-      span.instance_variable_set(:@ended, true)
-      span.instance_variable_set(:@context, span_context)
-      # Seed the nested attribute structure the gem assumes exists: Span#name reads
-      # @attributes[:data][:sdk][:name] and set_tag (via add_attributes) writes under
-      # @attributes[:data][:sdk]. allocate skips initialize, so without this seed
-      # those raise NoMethodError. :ts is seeded because close computes
-      # end_time - @attributes[:ts] (harmless here since close short-circuits on @ended).
-      span.instance_variable_set(:@attributes, { data: { sdk: {} }, ts: 0 })
-      span
+      Instana::Span.non_recording(span_context)
     end
   end
 end

--- a/lib/instana/trace.rb
+++ b/lib/instana/trace.rb
@@ -56,14 +56,32 @@ module Instana
       OpenTelemetry::Context.with_value(CURRENT_SPAN_KEY, span) { |c, s| yield s, c }
     end
 
-    # Wraps a SpanContext with an object implementing the Span interface. This is done in order
-    # to expose a SpanContext as a Span in operations such as in-process Span propagation.
+    # Wraps a SpanContext with an object implementing the Span interface.
+    #
+    # Returns a non-recording (pre-ended) Instana::Span rather than a bare
+    # OpenTelemetry::Trace::Span. A bare span breaks dropped-trace handling in two
+    # ways: (1) the OpenTracing-style log_entry/trace API builds a child via
+    # Span.new(name, current_span), but Span#initialize only accepts a parent that
+    # is_a?(Instana::Span) or is_a?(Instana::SpanContext) -- a bare span matches
+    # neither, so the child becomes a parentless root whose log_exit sets
+    # current_span to nil, severing context before outbound calls; (2) the bare span
+    # lacks name/parent. A pre-ended Instana::Span satisfies the parent check,
+    # carries @parent natively, reports recording? == false (recording? is !@ended),
+    # and never exports because Span#close short-circuits when @ended (see span.rb).
     #
     # @param [SpanContext] span_context SpanContext to be wrapped
-    #
     # @return [Span]
     def non_recording_span(span_context)
-      OpenTelemetry::Trace::Span.new(span_context: span_context)
+      span = Instana::Span.allocate
+      span.instance_variable_set(:@ended, true)
+      span.instance_variable_set(:@context, span_context)
+      # Seed the nested attribute structure the gem assumes exists: Span#name reads
+      # @attributes[:data][:sdk][:name] and set_tag (via add_attributes) writes under
+      # @attributes[:data][:sdk]. allocate skips initialize, so without this seed
+      # those raise NoMethodError. :ts is seeded because close computes
+      # end_time - @attributes[:ts] (harmless here since close short-circuits on @ended).
+      span.instance_variable_set(:@attributes, { data: { sdk: {} }, ts: 0 })
+      span
     end
   end
 end

--- a/lib/instana/trace/span.rb
+++ b/lib/instana/trace/span.rb
@@ -163,6 +163,12 @@ module Instana
     # @return [Span]
     #
     def close(end_time = ::Instana::Util.now_in_ms)
+      # A non-recording span (built by Instana::Trace.non_recording_span) is created
+      # pre-ended (@ended = true). Without this guard, close would queue it for
+      # export to the agent, counting dropped spans against the Fair Use Policy and
+      # defeating head sampling. Skip any span that is already ended.
+      return self if @ended
+
       result = ::Instana::SpanFiltering.filter_span(self)
       if end_time.is_a?(Time)
         end_time = ::Instana::Util.time_to_ms(end_time)

--- a/lib/instana/trace/span.rb
+++ b/lib/instana/trace/span.rb
@@ -183,6 +183,17 @@ module Instana
       self
     end
 
+    # Builds a pre-ended span used to represent a non-recording (dropped or
+    # untraced) trace. See class doc / non_recording_span at Instana::Trace for
+    # full rationale.
+    def self.non_recording(span_context)
+      span = allocate
+      span.instance_variable_set(:@ended, true)
+      span.instance_variable_set(:@context, span_context)
+      span.instance_variable_set(:@attributes, { data: { sdk: {} }, ts: 0 })
+      span
+    end
+
     #############################################################
     # Accessors
     #############################################################

--- a/lib/instana/trace/tracer_provider.rb
+++ b/lib/instana/trace/tracer_provider.rb
@@ -144,14 +144,24 @@ module Instana
 
         if OpenTelemetry::Common::Utilities.untraced?(parent_context)
           span_id = parent_span_id || @id_generator.generate_span_id
-          return OpenTelemetry::Trace.non_recording_span(OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, span_id: span_id))
+          # Normalise the untraced span to a level-0 Instana::SpanContext (instead of a
+          # bare OTel SpanContext) so downstream gem code can call Instana-specific
+          # methods (level/active?/trace_parent_header) on it, and preserve the parent
+          # so the current_span chain walks correctly on log_exit/finish.
+          return build_dropped_span(trace_id: trace_id, span_id: span_id, tracestate: nil, parent_span: parent_span)
         end
 
-        result = @sampler.should_sample?(trace_id: trace_id, parent_context: parent_context, links: links, name: name, kind: kind, attributes: attributes)
+        result = @sampler.should_sample?(
+          trace_id: trace_id, parent_context: parent_context, links: links, name: name, kind: kind,
+          attributes: attributes
+        )
         span_id ||= @id_generator.generate_span_id
-        if !@stopped && result.recording? && !@stopped
-          trace_flags = result.sampled? ? OpenTelemetry::Trace::TraceFlags::SAMPLED : OpenTelemetry::Trace::TraceFlags::DEFAULT
-          context = Instana::SpanContext.new(trace_id: trace_id, span_id: span_id, trace_flags: trace_flags, tracestate: result.tracestate)
+        if !@stopped && result.recording?
+          trace_flags =
+            result.sampled? ? OpenTelemetry::Trace::TraceFlags::SAMPLED : OpenTelemetry::Trace::TraceFlags::DEFAULT
+          context = Instana::SpanContext.new(
+            trace_id: trace_id, span_id: span_id, trace_flags: trace_flags, tracestate: result.tracestate
+          )
           attributes = attributes&.merge(result.attributes) || result.attributes.dup
           Instana::Span.new(
             name,
@@ -169,7 +179,12 @@ module Instana
             instrumentation_scope
           )
         else
-          Instana::Trace.non_recording_span(Instana::Trace::SpanContext.new(trace_id: trace_id, span_id: span_id, tracestate: result.tracestate)) # Todo add tracestate so that the trcing doesnot happen for this span # rubocop:disable Layout/LineLength
+          # Sampler dropped this span. Build a non-recording, level-0 span that carries
+          # its parent, so the trace propagates sampled=0 downstream rather than
+          # severing context and producing orphan traces.
+          build_dropped_span(
+            trace_id: trace_id, span_id: span_id, tracestate: result.tracestate, parent_span: parent_span
+          )
         end
       end
 
@@ -192,6 +207,16 @@ module Instana
 
       def timeout_timestamp
         Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      # Builds a non-recording span for a dropped/untraced trace: an Instana::SpanContext
+      # forced to level 0 (so trace_parent_header emits sampled=0), wrapped in a
+      # non-recording span whose @parent is preserved for correct current_span unwinding.
+      def build_dropped_span(trace_id:, span_id:, tracestate:, parent_span:)
+        context = Instana::SpanContext.new(trace_id: trace_id, span_id: span_id, level: 0, tracestate: tracestate)
+        span = Instana::Trace.non_recording_span(context)
+        span.instance_variable_set(:@parent, parent_span) if parent_span
+        span
       end
     end
   end

--- a/lib/instana/trace/tracer_provider.rb
+++ b/lib/instana/trace/tracer_provider.rb
@@ -212,10 +212,13 @@ module Instana
       # Builds a non-recording span for a dropped/untraced trace: an Instana::SpanContext
       # forced to level 0 (so trace_parent_header emits sampled=0), wrapped in a
       # non-recording span whose @parent is preserved for correct current_span unwinding.
+      # @parent is guarded with is_a?(Instana::Span) to mirror Span#initialize and avoid
+      # storing OpenTelemetry::Trace::Span::INVALID (returned by current_span when no
+      # span is active), which would break the chain invariant.
       def build_dropped_span(trace_id:, span_id:, tracestate:, parent_span:)
         context = Instana::SpanContext.new(trace_id: trace_id, span_id: span_id, level: 0, tracestate: tracestate)
         span = Instana::Trace.non_recording_span(context)
-        span.instance_variable_set(:@parent, parent_span) if parent_span
+        span.instance_variable_set(:@parent, parent_span) if parent_span.is_a?(Instana::Span)
         span
       end
     end

--- a/test/support/fixed_sampler.rb
+++ b/test/support/fixed_sampler.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc. 2021
+
+# Minimal OpenTelemetry-shaped samplers for exercising TracerProvider's
+# recording vs non-recording branches deterministically, without depending on
+# the host application's Tracing::HeadSampler.
+
+module Instana
+  module TestSupport
+    # A sampler whose decision is fixed at construction.
+    class FixedSampler
+      Result = Struct.new(:sampled, :recording, :tracestate, :attributes) do
+        def sampled?
+          sampled
+        end
+
+        def recording?
+          recording
+        end
+      end
+
+      def initialize(sampled:)
+        @sampled = sampled
+      end
+
+      def should_sample?(trace_id:, parent_context:, links:, name:, kind:, attributes:) # rubocop:disable Lint/UnusedMethodArgument, Metrics/ParameterLists
+        Result.new(@sampled, @sampled, OpenTelemetry::Trace::Tracestate::DEFAULT, {})
+      end
+
+      def description
+        "Instana::TestSupport::FixedSampler(sampled=#{@sampled})"
+      end
+    end
+
+    # Always drops (non-recording).
+    def self.dropping_sampler
+      FixedSampler.new(sampled: false)
+    end
+
+    # Always keeps (recording).
+    def self.keeping_sampler
+      FixedSampler.new(sampled: true)
+    end
+  end
+end

--- a/test/trace/rack_context_leak_test.rb
+++ b/test/trace/rack_context_leak_test.rb
@@ -1,0 +1,60 @@
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc. 2024
+
+# Instana::Rack must always detach the attached OpenTelemetry
+# context token, even on a dropped trace where current_span has collapsed to nil
+# and finalize_trace's span work is skipped. Otherwise the token leaks into the
+# next request on a reused thread.
+class RackContextLeakTest < Minitest::Test
+  def setup
+    @middleware = Instana::Rack.new(->(_env) { [200, {}, ['ok']] })
+  end
+
+  def test_finalize_trace_detaches_token_when_not_tracing
+    detached = []
+    token = OpenTelemetry::Context.attach(OpenTelemetry::Context.current)
+    @middleware.instance_variable_set(:@trace_token, token)
+
+    OpenTelemetry::Context.stub(:detach, ->(t) { detached << t }) do
+      # current_span nil -> not tracing; span work skipped, but detach must run.
+      @middleware.send(:finalize_trace, nil, {}, {}, nil)
+    end
+
+    assert_includes detached, token
+    assert_nil @middleware.instance_variable_get(:@trace_token)
+  end
+
+  def test_finalize_trace_finishes_span_and_detaches_when_tracing
+    detached = []
+    ctx = Instana::SpanContext.new(trace_id: 'abc123', span_id: 'def456', level: 1)
+    span = Instana::Span.new(:rack, ctx)
+    token = OpenTelemetry::Context.attach(OpenTelemetry::Context.current)
+    @middleware.instance_variable_set(:@trace_token, token)
+    ::Instana.tracer.current_span = span
+
+    OpenTelemetry::Context.stub(:detach, ->(t) { detached << t }) do
+      ::Instana.processor.stub(:on_finish, ->(_) {}) do
+        # headers: nil makes finalize_trace skip set_response_headers (guarded by `if
+        # headers`), which would otherwise call active? on the nil trace_context. This
+        # test only exercises the span-finish + detach path, not response headers.
+        @middleware.send(:finalize_trace, span, {}, nil, nil)
+      end
+    end
+
+    assert_includes detached, token
+    assert_nil @middleware.instance_variable_get(:@trace_token)
+  ensure
+    ::Instana.tracer.current_span = nil
+  end
+
+  def test_finalize_trace_without_token_is_noop_on_detach
+    detached = []
+    @middleware.instance_variable_set(:@trace_token, nil)
+
+    OpenTelemetry::Context.stub(:detach, ->(t) { detached << t }) do
+      @middleware.send(:finalize_trace, nil, {}, {}, nil)
+    end
+
+    assert_empty detached
+  end
+end

--- a/test/trace/span_test.rb
+++ b/test/trace/span_test.rb
@@ -3,7 +3,7 @@
 
 require 'test_helper'
 
-class SpanTest < Minitest::Test
+class SpanTest < Minitest::Test # rubocop:disable Metrics/ClassLength
   def test_getters_setters
     span = Instana::Span.new(:test)
 
@@ -401,5 +401,49 @@ class SpanTest < Minitest::Test
     refute_equal first_stack, span[:stack], "Stack trace should be updated with second error"
   ensure
     Instana.config[:back_trace][:stack_trace_level] = "error"
+  end
+
+  # --- non_recording_span returns a pre-ended Instana::Span ---------
+
+  def test_non_recording_span_returns_instana_span
+    ctx = Instana::SpanContext.new(trace_id: 'abc123', span_id: 'def456', level: 0)
+    assert_instance_of Instana::Span, Instana::Trace.non_recording_span(ctx)
+  end
+
+  def test_non_recording_span_is_not_recording
+    ctx = Instana::SpanContext.new(trace_id: 'abc123', span_id: 'def456', level: 0)
+    refute Instana::Trace.non_recording_span(ctx).recording?
+  end
+
+  def test_non_recording_span_preserves_context
+    ctx = Instana::SpanContext.new(trace_id: 'abc123', span_id: 'def456', level: 0)
+    assert_same ctx, Instana::Trace.non_recording_span(ctx).context
+  end
+
+  def test_non_recording_span_name_does_not_raise
+    ctx = Instana::SpanContext.new(trace_id: 'abc123', span_id: 'def456', level: 0)
+    assert_nil Instana::Trace.non_recording_span(ctx).name
+  end
+
+  def test_non_recording_span_add_attributes_does_not_raise
+    ctx = Instana::SpanContext.new(trace_id: 'abc123', span_id: 'def456', level: 0)
+    Instana::Trace.non_recording_span(ctx).add_attributes(foo: 'bar')
+  end
+
+  # --- Span#close short-circuits on an already-ended span -----------
+
+  def test_pre_ended_span_does_not_export_on_close
+    clear_all!
+    ctx = Instana::SpanContext.new(trace_id: 'abc123', span_id: 'def456', level: 0)
+    span = Instana::Trace.non_recording_span(ctx)
+    assert_same span, span.close
+    assert_equal 0, Instana.processor.span_metrics[:closed]
+  end
+
+  def test_recording_span_still_exports_on_close
+    clear_all!
+    span = Instana::Span.new(:rack)
+    span.close
+    assert_equal 1, Instana.processor.span_metrics[:closed]
   end
 end

--- a/test/trace/span_test.rb
+++ b/test/trace/span_test.rb
@@ -405,29 +405,24 @@ class SpanTest < Minitest::Test # rubocop:disable Metrics/ClassLength
 
   # --- non_recording_span returns a pre-ended Instana::Span ---------
 
-  def test_non_recording_span_returns_instana_span
-    ctx = Instana::SpanContext.new(trace_id: 'abc123', span_id: 'def456', level: 0)
-    assert_instance_of Instana::Span, Instana::Trace.non_recording_span(ctx)
-  end
-
   def test_non_recording_span_is_not_recording
     ctx = Instana::SpanContext.new(trace_id: 'abc123', span_id: 'def456', level: 0)
-    refute Instana::Trace.non_recording_span(ctx).recording?
+    refute Instana::Span.non_recording(ctx).recording?
   end
 
   def test_non_recording_span_preserves_context
     ctx = Instana::SpanContext.new(trace_id: 'abc123', span_id: 'def456', level: 0)
-    assert_same ctx, Instana::Trace.non_recording_span(ctx).context
+    assert_same ctx, Instana::Span.non_recording(ctx).context
   end
 
-  def test_non_recording_span_name_does_not_raise
+  def test_non_recording_returns_nameless_span
     ctx = Instana::SpanContext.new(trace_id: 'abc123', span_id: 'def456', level: 0)
-    assert_nil Instana::Trace.non_recording_span(ctx).name
+    assert_nil Instana::Span.non_recording(ctx).name
   end
 
   def test_non_recording_span_add_attributes_does_not_raise
     ctx = Instana::SpanContext.new(trace_id: 'abc123', span_id: 'def456', level: 0)
-    Instana::Trace.non_recording_span(ctx).add_attributes(foo: 'bar')
+    Instana::Span.non_recording(ctx).add_attributes(foo: 'bar')
   end
 
   # --- Span#close short-circuits on an already-ended span -----------
@@ -435,7 +430,7 @@ class SpanTest < Minitest::Test # rubocop:disable Metrics/ClassLength
   def test_pre_ended_span_does_not_export_on_close
     clear_all!
     ctx = Instana::SpanContext.new(trace_id: 'abc123', span_id: 'def456', level: 0)
-    span = Instana::Trace.non_recording_span(ctx)
+    span = Instana::Span.non_recording(ctx)
     assert_same span, span.close
     assert_equal 0, Instana.processor.span_metrics[:closed]
   end

--- a/test/trace/tracer_provider_test.rb
+++ b/test/trace/tracer_provider_test.rb
@@ -10,6 +10,18 @@ class TracerProviderTest < Minitest::Test
     @tracer_provider = Instana.tracer_provider
   end
 
+  def dropping_provider
+    ::Instana::Trace::TracerProvider.new(sampler: Instana::TestSupport.dropping_sampler)
+  end
+
+  def keeping_provider
+    ::Instana::Trace::TracerProvider.new(sampler: Instana::TestSupport.keeping_sampler)
+  end
+
+  def start_root(provider, name: :rack)
+    provider.internal_start_span(name, :internal, {}, [], Time.now, nil, nil)
+  end
+
   def test_tracer
     # This tests the global tracer is the same as tracer from tracer_provider
     assert_equal Instana.tracer, @tracer_provider.tracer("instana_tracer")
@@ -111,27 +123,46 @@ class TracerProviderTest < Minitest::Test
   end
 
   def test_internal_start_span_untraced
-    @tracer_provider = ::Instana::Trace::TracerProvider.new
-    Minitest::Mock.new
-    result = @tracer_provider.internal_start_span('test_span', 'kind', {}, [], Time.now, nil, @instrumentation_scope)
-    assert_instance_of(Instana::Span, result)
-    # Todo add proper testcase
+    # An untraced parent context yields a non-recording, level-0 Instana::Span.
+    untraced = OpenTelemetry::Common::Utilities.untraced
+    span = @tracer_provider.internal_start_span('test_span', :internal, {}, [], Time.now, untraced, nil)
+
+    assert_instance_of Instana::Span, span
+    refute span.recording?
+    assert_equal 0, span.context.level
+    assert_match(/-02\z/, span.context.trace_parent_header)
   end
 
-  def test_internal_start_span_traced
-    @tracer_provider = ::Instana::Trace::TracerProvider.new
-    Minitest::Mock.new
-    result = @tracer_provider.internal_start_span('test_span', 'kind', {}, [], Time.now, nil, @instrumentation_scope)
-    assert_instance_of(Instana::Span, result)
-    # Todo add proper testcase
+  def test_internal_start_span_dropped
+    span = start_root(dropping_provider)
+
+    assert_instance_of Instana::Span, span
+    refute span.recording?
+    assert_equal 0, span.context.level
+    assert_match(/-02\z/, span.context.trace_parent_header)
   end
 
-  def test_internal_start_span_stopped
-    @tracer_provider = ::Instana::Trace::TracerProvider.new
-    Minitest::Mock.new
-    result = @tracer_provider.internal_start_span('test_span', 'kind', {}, [], Time.now, nil, @instrumentation_scope)
-    assert_instance_of(Instana::Span, result)
-    # Todo add proper testcase
+  def test_internal_start_span_kept
+    span = start_root(keeping_provider)
+
+    assert_instance_of Instana::Span, span
+    assert span.recording?
+    assert_match(/-03\z/, span.context.trace_parent_header)
+  end
+
+  def test_internal_start_span_dropped_preserves_parent
+    provider = dropping_provider
+    parent = start_root(provider, name: :rack)
+    child = Instana::Trace.with_span(parent) { start_root(provider, name: :actioncontroller) }
+
+    assert_equal parent, child.instance_variable_get(:@parent)
+  end
+
+  def test_internal_start_span_when_stopped
+    provider = keeping_provider
+    provider.shutdown
+    span = start_root(provider)
+    refute span.recording? # stopped forces non-recording even though sampler keeps
   end
 end
 

--- a/test/trace/tracer_provider_test.rb
+++ b/test/trace/tracer_provider_test.rb
@@ -130,7 +130,7 @@ class TracerProviderTest < Minitest::Test
     assert_instance_of Instana::Span, span
     refute span.recording?
     assert_equal 0, span.context.level
-    assert_match(/-02\z/, span.context.trace_parent_header)
+    assert_match(/-02\z/, span.context.trace_parent_header) # W3C traceparent flags: 02 = not sampled
   end
 
   def test_internal_start_span_dropped
@@ -139,7 +139,7 @@ class TracerProviderTest < Minitest::Test
     assert_instance_of Instana::Span, span
     refute span.recording?
     assert_equal 0, span.context.level
-    assert_match(/-02\z/, span.context.trace_parent_header)
+    assert_match(/-02\z/, span.context.trace_parent_header) # W3C traceparent flags: 02 = not sampled
   end
 
   def test_internal_start_span_kept
@@ -147,7 +147,7 @@ class TracerProviderTest < Minitest::Test
 
     assert_instance_of Instana::Span, span
     assert span.recording?
-    assert_match(/-03\z/, span.context.trace_parent_header)
+    assert_match(/-03\z/, span.context.trace_parent_header) # W3C traceparent flags: 03 = sampled
   end
 
   def test_internal_start_span_dropped_preserves_parent
@@ -158,10 +158,17 @@ class TracerProviderTest < Minitest::Test
     assert_equal parent, child.instance_variable_get(:@parent)
   end
 
+  def test_internal_start_span_dropped_root_has_nil_parent
+    span = start_root(dropping_provider)
+    assert_nil span.instance_variable_get(:@parent)
+  end
+
   def test_internal_start_span_when_stopped
     provider = keeping_provider
     provider.shutdown
     span = start_root(provider)
+    assert_instance_of Instana::Span, span
+
     refute span.recording? # stopped forces non-recording even though sampler keeps
   end
 end

--- a/test/trace/tracer_test.rb
+++ b/test/trace/tracer_test.rb
@@ -360,4 +360,13 @@ class TracerTest < Minitest::Test
       Instana::Tracer.invalid
     end
   end
+
+  def test_non_recording_span_delegates_to_span
+    ctx = Instana::SpanContext.new(trace_id: 'abc', span_id: 'def', level: 0)
+    span = Instana::Trace.non_recording_span(ctx)
+
+    assert_instance_of Instana::Span, span
+    refute span.recording?
+    assert_same ctx, span.context
+  end
 end


### PR DESCRIPTION
- Added support for creating non-recording spans for dropped traces while preserving correct parent relationships.
- Enhanced span management in `TracerProvider` to normalize the context and ensure seamless context propagation.
- Updated `Instana::Trace::Span` to short-circuit `close` for pre-ended spans, preventing unnecessary processing or export to the agent.
- Fixed token detachment in `Rack` to prevent context leakage on reused threads.
- Added related unit tests, including for `non_recording_span`, dropped spans, and context detachment.
- Introduced minimal fixed samplers in test support for deterministic testing.

The related RFC is in ths PR: https://github.com/transportapi/engineering/pull/208