### PR TITLE
Bump version to 2.7.0.1

### DIFF
--- a/lib/instana/version.rb
+++ b/lib/instana/version.rb
@@ -2,6 +2,6 @@
 # (c) Copyright Instana Inc. 2016
 
 module Instana
-  VERSION = "2.7.0"
+  VERSION = "2.7.0.1"
   VERSION_FULL = "instana-#{VERSION}"
 end


### PR DESCRIPTION
## Version bump to 2.7.0.1

Bumps `Instana::VERSION` to `2.7.0.1`.

### Versioning scheme

`2.7.0.1` is a Ruby gem build-of-a-release version: a fourth segment appended
to upstream's `2.7.0`. It signals "based on 2.7.0, with our additions" and
sorts after `2.7.0` but before any future upstream `2.7.1`, so it won't
collide with upstream releases.

