### PR TITLE
Refactor `Rack` middleware to avoid shared instance variable for trace tokens

### DIFF
--- a/lib/instana/instrumentation/rack.rb
+++ b/lib/instana/instrumentation/rack.rb
@@ -23,7 +23,7 @@ module Instana
 
       current_span = ::Instana.tracer.start_span(:rack, attributes: {}, with_parent: parent_context)
       trace_ctx = OpenTelemetry::Trace.context_with_span(current_span)
-      @trace_token = OpenTelemetry::Context.attach(trace_ctx)
+      trace_token = OpenTelemetry::Context.attach(trace_ctx)
       status, headers, response = @app.call(env)
 
       trace_context = process_span_tags(req, current_span, kvs, status, env) if ::Instana.tracer.tracing?
@@ -33,7 +33,7 @@ module Instana
       current_span.record_exception(e) if ::Instana.tracer.tracing?
       raise
     ensure
-      finalize_trace(current_span, kvs, headers, trace_context)
+      finalize_trace(current_span, kvs, headers, trace_context, trace_token)
     end
 
     private
@@ -120,17 +120,14 @@ module Instana
       end
     end
 
-    def finalize_trace(current_span, kvs, headers, trace_context)
+    def finalize_trace(current_span, kvs, headers, trace_context, trace_token)
       if ::Instana.tracer.tracing?
         set_response_headers(headers, trace_context) if headers
         current_span.add_attributes(kvs)
         current_span.finish
       end
     ensure
-      if @trace_token
-        OpenTelemetry::Context.detach(@trace_token)
-        @trace_token = nil
-      end
+      OpenTelemetry::Context.detach(trace_token) if trace_token
     end
 
     def set_response_headers(headers, trace_context)

--- a/test/trace/rack_context_leak_test.rb
+++ b/test/trace/rack_context_leak_test.rb
@@ -12,49 +12,61 @@ class RackContextLeakTest < Minitest::Test
 
   def test_finalize_trace_detaches_token_when_not_tracing
     detached = []
-    token = OpenTelemetry::Context.attach(OpenTelemetry::Context.current)
-    @middleware.instance_variable_set(:@trace_token, token)
+    token = :fake_token
 
     OpenTelemetry::Context.stub(:detach, ->(t) { detached << t }) do
-      # current_span nil -> not tracing; span work skipped, but detach must run.
-      @middleware.send(:finalize_trace, nil, {}, {}, nil)
+      @middleware.send(:finalize_trace, nil, {}, {}, nil, token)
     end
 
     assert_includes detached, token
-    assert_nil @middleware.instance_variable_get(:@trace_token)
   end
 
   def test_finalize_trace_finishes_span_and_detaches_when_tracing
     detached = []
     ctx = Instana::SpanContext.new(trace_id: 'abc123', span_id: 'def456', level: 1)
     span = Instana::Span.new(:rack, ctx)
-    token = OpenTelemetry::Context.attach(OpenTelemetry::Context.current)
-    @middleware.instance_variable_set(:@trace_token, token)
+    token = :fake_token
     ::Instana.tracer.current_span = span
 
     OpenTelemetry::Context.stub(:detach, ->(t) { detached << t }) do
       ::Instana.processor.stub(:on_finish, ->(_) {}) do
-        # headers: nil makes finalize_trace skip set_response_headers (guarded by `if
-        # headers`), which would otherwise call active? on the nil trace_context. This
-        # test only exercises the span-finish + detach path, not response headers.
-        @middleware.send(:finalize_trace, span, {}, nil, nil)
+        @middleware.send(:finalize_trace, span, {}, nil, nil, token)
       end
     end
 
     assert_includes detached, token
-    assert_nil @middleware.instance_variable_get(:@trace_token)
   ensure
     ::Instana.tracer.current_span = nil
   end
 
-  def test_finalize_trace_without_token_is_noop_on_detach
-    detached = []
-    @middleware.instance_variable_set(:@trace_token, nil)
+  def test_concurrent_calls_do_not_share_token
+    attached = Queue.new
+    detached = Queue.new
+    call_count = 0
 
-    OpenTelemetry::Context.stub(:detach, ->(t) { detached << t }) do
-      @middleware.send(:finalize_trace, nil, {}, {}, nil)
+    app = lambda { |_env|
+      call_count += 1
+      sleep 0.05 # widen the race window
+      [200, {}, ['ok']]
+    }
+    middleware = Instana::Rack.new(app)
+
+    OpenTelemetry::Context.stub(:attach, lambda { |_|
+      token = Object.new
+      attached << token
+      token
+    }) do
+      OpenTelemetry::Context.stub(:detach, ->(t) { detached << t }) do
+        threads = 5.times.map { Thread.new { middleware.call({}) } }
+        threads.each(&:join)
+      end
     end
 
-    assert_empty detached
+    # Every attached token must have a matching detach — no token lost or doubled.
+    attached_set = []
+    detached_set = []
+    attached_set << attached.pop until attached.empty?
+    detached_set << detached.pop until detached.empty?
+    assert_equal attached_set.sort_by(&:object_id), detached_set.sort_by(&:object_id)
   end
 end

--- a/test/trace/rack_context_leak_test.rb
+++ b/test/trace/rack_context_leak_test.rb
@@ -39,13 +39,17 @@ class RackContextLeakTest < Minitest::Test
     ::Instana.tracer.current_span = nil
   end
 
+  def test_finalize_trace_skips_detach_when_token_is_nil
+    OpenTelemetry::Context.stub(:detach, ->(_) { flunk "detach must not be called" }) do
+      @middleware.send(:finalize_trace, nil, {}, {}, nil, nil)
+    end
+  end
+
   def test_concurrent_calls_do_not_share_token
     attached = Queue.new
     detached = Queue.new
-    call_count = 0
 
     app = lambda { |_env|
-      call_count += 1
       sleep 0.05 # widen the race window
       [200, {}, ['ok']]
     }


### PR DESCRIPTION
## Fix shared @trace_token race under concurrent Puma threads

`Instana::Rack` stored the OTel context token in `@trace_token` — an instance
variable on the singleton middleware, shared across all threads in a Puma
worker. Concurrent requests overwrote each other's tokens, causing detach
to release the wrong token (out of LIFO order).

Observed in production:

> OpenTelemetry error: calls to detach should match corresponding calls to attach.

Fix: pass the token as a local variable through `call` → `finalize_trace`.
Each request has its own stack frame, so attach/detach pair correctly on
the same thread without cross-request interference.

### Tests

- Existing leak-fix tests updated to pass the token as a parameter.
- New test exercises 5 concurrent calls and asserts every attached token
  has a matching detach — fails on the shared-ivar version, passes on
  the local-variable fix.